### PR TITLE
Add distance threshold to settings.

### DIFF
--- a/napari/layers/shapes/_shapes_mouse_bindings.py
+++ b/napari/layers/shapes/_shapes_mouse_bindings.py
@@ -14,6 +14,7 @@ from napari.layers.shapes._shapes_models import (
     Rectangle,
 )
 from napari.layers.shapes._shapes_utils import point_to_lines
+from napari.settings import get_settings
 
 if TYPE_CHECKING:
     from typing import List, Optional, Tuple
@@ -393,7 +394,10 @@ def polygon_creating(layer: Shapes, event: MouseEvent) -> None:
             position_diff = np.linalg.norm(
                 event.pos - layer._last_cursor_position
             )
-            if position_diff > 10:
+            if (
+                position_diff
+                > get_settings().experimental.lasso_vertex_distance
+            ):
                 add_vertex_to_path(layer, event, index, coordinates, None)
 
 

--- a/napari/settings/_experimental.py
+++ b/napari/settings/_experimental.py
@@ -47,6 +47,17 @@ class ExperimentalSettings(EventedSettings):
         ge=0,
     )
 
+    lasso_vertex_distance: int = Field(
+        10,
+        title=trans._("Minimum distance threshold of shapes lasso tool"),
+        description=trans._(
+            "Value determines how many screen pixels one has to move before another vertex can be added to the polygon."
+        ),
+        type=int,
+        gt=0,
+        lt=50,
+    )
+
     class NapariConfig:
         # Napari specific configuration
         preferences_exclude = ['schema_version']


### PR DESCRIPTION
Add a vertex distance threshold to the settings determining how many screen pixels a user needs to move the mouse before another vertex can be added.